### PR TITLE
Redocly rules

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,6 +23,7 @@
     "operationid",
     "owasp",
     "quobix",
+    "redocly",
     "ruleset",
     "rulesets"
   ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -6854,6 +6854,7 @@
         "rate-my-openapi": "rate-my-openapi.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.5",
         "@types/node": "^20.4.6",
         "@types/prettier": "^2.7.3",
         "@types/yargs": "^17.0.24",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
     ]
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.5",
     "@types/node": "^20.4.6",
     "@types/prettier": "^2.7.3",
     "@types/yargs": "^17.0.24",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,14 +41,17 @@ In addition to an overall score for each level of hierarchy, additional category
 scores were created by specifically focusing on sets of rules that were deemed
 most important to those categories. The current categories are:
 
-- Docs Quality: Measure of quality of documentation that can be generated from
-  this spec. Missing fields like examples and responses affects this score.
-- Completeness: How complete is this OpenAPI spec? Does it fill out many of the
-  non-required but nice-to-have properties? Missing fields like descriptions
+- **Docs Quality**: Measure of quality of documentation that can be generated
+  from this spec. We utilized recommendations from
+  [Redocly](https://redocly.com/docs/cli/rules/built-in-rules/) to generate this
+  score. Missing fields like examples and responses affects this score.
+- **Completeness**: How complete is this OpenAPI spec? Does it fill out many of
+  the non-required but nice-to-have properties? Missing fields like descriptions
   affects this score.
-- SDK Generation: How suitable is this OpenAPI spec for generating an SDK? We
-  utilized recommendations from Apimatic to generate this score. Proper naming
-  and component usage affect this score.
-- Security (Inspired by OWASP recommendations): How vulnerable is this API to
-  OWASP's Top 10 attack vectors? Contract-testing plays a large role here, so
+- **SDK Generation**: How suitable is this OpenAPI spec for generating an SDK?
+  We utilized recommendations from
+  [Apimatic](https://www.apimatic.io/blog/2022/11/14-best-practices-to-write-openapi-for-better-api-consumption/)
+  to generate this score. Proper naming and component usage affect this score.
+- **Security (Inspired by OWASP recommendations)**: How vulnerable is this API
+  to OWASP's Top 10 attack vectors? Contract-testing plays a large role here, so
   documenting all possible responses affects this score.

--- a/packages/core/src/completeness-rating-utils.ts
+++ b/packages/core/src/completeness-rating-utils.ts
@@ -21,7 +21,10 @@ export const COMPLETENESS_ISSUES = [
   'operation-tags',
   'openapi-tags',
   'operation-tag-defined',
-  'oas3-operation-security-defined'
+  'oas3-operation-security-defined',
+  "redocly-operation-summary",
+  "redocly-no-server-variables-empty-enum",
+  "redocly-no-undefined-server-variable",
 ]
 
 export const getCompletenessRating = (issues: SpectralReport) => {

--- a/packages/core/src/docs-rating-utils.ts
+++ b/packages/core/src/docs-rating-utils.ts
@@ -10,6 +10,7 @@ export const DOCS_ISSUES = [
   "operation-operationId",
   "operation-operationId-unique",
   "oas3-host-not-example",
+  "oas3-host-trailing-slash",
   "contact-properties",
   "info-description",
   "oas3-api-servers",
@@ -21,6 +22,15 @@ export const DOCS_ISSUES = [
   "operation-tags",
   "openapi-tags",
   "operation-tag-defined",
+  "typed-enum",
+  "duplicated-entry-in-enum",
+  "path-keys-no-trailing-slash",
+  "operation-parameters",
+  "path-params",
+  "path-not-include-query",
+  "redocly-operation-summary",
+  "redocly-no-server-variables-empty-enum",
+  "redocly-no-undefined-server-variable",
 ];
 
 export const getDocsRating = (issues: SpectralReport) => {

--- a/packages/core/src/rating-utils.ts
+++ b/packages/core/src/rating-utils.ts
@@ -148,7 +148,7 @@ export const generateOpenApiRating = (
     : // Having tags is not mandatory, so we count this as a single warning
       // TODO: Should we penalize harder for having more paths?
       {
-        score: 85,
+        score: 0,
         issues: issuesByArea.tags,
         docsScore: 85,
         docsIssues: getDocsIssues(issuesByArea.tags),
@@ -189,15 +189,15 @@ export const generateOpenApiRating = (
       // as a single warning. Security can also be documented at the operation
       // level.
       {
-        score: 85,
+        score: 0,
         issues: issuesByArea.security,
-        docsScore: 85,
+        docsScore: 0,
         docsIssues: getDocsIssues(issuesByArea.security),
-        completenessScore: 85, // May exist at the op level so only warning
+        completenessScore: 0, // May exist at the op level so only warning
         completenessIssues: getCompletenessIssues(issuesByArea.security),
-        sdkGenerationScore: 85,
+        sdkGenerationScore: 0,
         sdkGenerationIssues: getSdkGenerationIssues(issuesByArea.security),
-        securityScore: 85, // May exist at the op level so only warning
+        securityScore: 0, // Should exist but be an empty array
         securityIssues: getSecurityIssues(issuesByArea.security),
       };
 

--- a/packages/core/src/sdk-rating-utils.ts
+++ b/packages/core/src/sdk-rating-utils.ts
@@ -39,6 +39,7 @@ const APIMATIC_SDK_ISSUES = [
   "operation-operationId-valid-in-url", // Rec 8
   "operation-success-response", // Rec 9
   "operation-tags", // Rec 10
+  "redocly-components-invalid-map-name"
 ];
 
 export const SDK_ISSUES = [...APIMATIC_SDK_ISSUES];

--- a/rulesets/.spectral-supplement.yaml
+++ b/rulesets/.spectral-supplement.yaml
@@ -172,3 +172,45 @@ rules:
       function: pattern
       functionOptions:
         match: "/^https:/"
+  redocly-operation-summary:
+    message: Operation should have a summary
+    description: "Operation summaries are used to generate API docs. Redocly uses the summary as the header for the operation, as well as the sidebar navigation text. See https://redocly.com/docs/cli/rules/operation-summary/"
+    severity: warn
+    given: "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]"
+    then:
+      - field: "summary"
+        function: truthy
+  redocly-components-invalid-map-name:
+    message: All component names MUST consist of the following characters `A..Z a..z 0..9 . _ -`
+    description: "All components MUST use keys that match the regular expression: ^[a-zA-Z0-9.-_]+$ See https://redocly.com/docs/cli/rules/spec-components-invalid-map-name/"
+    severity: error
+    given:
+      - "$.components.schemas[*]~"
+      - "$.components.parameters[*]~"
+      - "$.components.securitySchemes[*]~"
+      - "$.components.requestBodies[*]~"
+      - "$.components.responses[*]~"
+      - "$.components.headers[*]~"
+      - "$.components.examples[*]~"
+      - "$.components.links[*]~"
+      - "$.components.callbacks[*]~"
+    then:
+      function: pattern
+      functionOptions:
+        match: ^[a-zA-Z0-9._-]+$
+  redocly-no-server-variables-empty-enum:
+    message: "Server variables defined, but no enum of options provided"
+    description: "If you use server variables, there are generally two kinds: tenant-driven and environment-driven. In the case of environment-driven variables, you may want to predefine all of the possible values. See https://redocly.com/docs/cli/rules/no-server-variables-empty-enum/"
+    severity: warn
+    given: "$.servers[*].variables[*]"
+    then:
+      field: "enum"
+      function: defined
+  redocly-no-undefined-server-variable:
+    message: "Variable was declared in server URL but not documented"
+    description: "Document all declared server variables to make it easier to consume the API. See https://redocly.com/docs/cli/rules/no-undefined-server-variable/"
+    severity: warn
+    given: "$.servers[?(@.url.match(/({)/))]"
+    then:
+      field: "variables"
+      function: defined

--- a/rulesets/.spectral.yaml
+++ b/rulesets/.spectral.yaml
@@ -204,3 +204,45 @@ rules:
       function: pattern
       functionOptions:
         match: "/^https:/"
+  redocly-operation-summary:
+    message: Operation should have a summary
+    description: "Operation summaries are used to generate API docs. Redocly uses the summary as the header for the operation, as well as the sidebar navigation text. See https://redocly.com/docs/cli/rules/operation-summary/"
+    severity: warn
+    given: "$.paths.*[?( @property === 'get' || @property === 'put' || @property === 'post' || @property === 'delete' || @property === 'options' || @property === 'head' || @property === 'patch' || @property === 'trace' )]"
+    then:
+      - field: "summary"
+        function: truthy
+  redocly-components-invalid-map-name:
+    message: All component names MUST consist of the following characters `A..Z a..z 0..9 . _ -`
+    description: "All components MUST use keys that match the regular expression: ^[a-zA-Z0-9.-_]+$ See https://redocly.com/docs/cli/rules/spec-components-invalid-map-name/"
+    severity: error
+    given:
+      - "$.components.schemas[*]~"
+      - "$.components.parameters[*]~"
+      - "$.components.securitySchemes[*]~"
+      - "$.components.requestBodies[*]~"
+      - "$.components.responses[*]~"
+      - "$.components.headers[*]~"
+      - "$.components.examples[*]~"
+      - "$.components.links[*]~"
+      - "$.components.callbacks[*]~"
+    then:
+      function: pattern
+      functionOptions:
+        match: ^[a-zA-Z0-9._-]+$
+  redocly-no-server-variables-empty-enum:
+    message: "Server variables defined, but no enum of options provided"
+    description: "If you use server variables, there are generally two kinds: tenant-driven and environment-driven. In the case of environment-driven variables, you may want to predefine all of the possible values. See https://redocly.com/docs/cli/rules/no-server-variables-empty-enum/"
+    severity: warn
+    given: "$.servers[*].variables[*]"
+    then:
+      field: "enum"
+      function: defined
+  redocly-no-undefined-server-variable:
+    message: "Variable was declared in server URL but not documented"
+    description: "Document all declared server variables to make it easier to consume the API. See https://redocly.com/docs/cli/rules/no-undefined-server-variable/"
+    severity: warn
+    given: "$.servers[?(@.url.match(/({)/))]"
+    then:
+      field: "variables"
+      function: defined

--- a/rulesets/rules.vacuum.yaml
+++ b/rulesets/rules.vacuum.yaml
@@ -17,5 +17,5 @@ rules:
   openapi-tags-alphabetical: false
   # Noisy and unnecessary
   description-duplication: false
-  # Not a big deal
+  # Covered by oas3-api-servers
   oas3-host-trailing-slash: false


### PR DESCRIPTION
## Summary

I added some new rules and adjusted some existing penalties based on how [redocly](https://redocly.com/docs/cli/rules/recommended/) evaluates OpenAPI files for documentation. This will primarily affect the overall score and documentation score

## New Rules
- Operation must include a summary (existing rule checks for either summary or description)
- Server variables must be defined if used in a `servers.url`
- Server variable values must be enumerated
- Component names must match the regex specified to be valid

I also made the penalty for not using tags or a top-level `security` object harsher based on feedback from @aabedraba 
