### PR TITLE
Fix monaco highlight

### DIFF
--- a/apps/web/src/components/Footer/index.tsx
+++ b/apps/web/src/components/Footer/index.tsx
@@ -18,6 +18,7 @@ export default function Footer() {
           <Link
             href="https://twitter.com/zuplo"
             className="group mr-3"
+            target="_blank"
             aria-label="Zuplo on Twitter"
           >
             <svg
@@ -30,6 +31,7 @@ export default function Footer() {
           <Link
             href="https://github.com/zuplo/rate-my-openapi"
             className="group"
+            target="_blank"
             aria-label="rate-my-openapi on GitHub"
           >
             <svg

--- a/apps/web/src/components/IssueModal/index.tsx
+++ b/apps/web/src/components/IssueModal/index.tsx
@@ -65,7 +65,7 @@ const IssueModal = ({
         range: selection,
         options: {
           isWholeLine: true,
-          blockClassName: getGlyphBackgroundClassName(issue.severity),
+          className: getGlyphBackgroundClassName(issue.severity),
           hoverMessage: { value: issue.message },
           minimap: {
             color: "rgba(254, 226, 226, 1)",


### PR DESCRIPTION
## Summary

Monaco changed what class should be used for decorations

## Preview

<img width="1285" alt="image" src="https://github.com/zuplo/rate-my-openapi/assets/11202679/92a77933-5cb7-4248-982f-f18652d42589">
