### PR TITLE
Fix reporUrl on sync-report & upload apis

### DIFF
--- a/apps/api/src/routes/sync-report.ts
+++ b/apps/api/src/routes/sync-report.ts
@@ -70,7 +70,7 @@ const syncReportRoute: FastifyPluginAsync = async function (server) {
       return reply.code(200).send({
         results,
         reportId,
-        reportUrl: `https://ratemyopenapi.com/rating/${reportId}`,
+        reportUrl: `https://ratemyopenapi.com/report/${reportId}`,
       });
     },
   });

--- a/apps/api/src/routes/upload.ts
+++ b/apps/api/src/routes/upload.ts
@@ -77,7 +77,7 @@ const uploadRoute: FastifyPluginAsync = async function (server) {
 
       reply.send({
         reportId,
-        reportUrl: `https://ratemyopenapi.com/rating/${reportId}`,
+        reportUrl: `https://ratemyopenapi.com/report/${reportId}`,
       });
     },
   });


### PR DESCRIPTION
This fixes the issue of getting 404s when using the `reportUrl` being returned.