### PR TITLE
Revert "Rename cli to ramoa (#258)"

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -55,6 +55,6 @@ jobs:
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.com"
-
+      
       # Sanity check to ensure that the package is published and runnable
-      - run: npx ramoa --help
+      - run: npx rmoa --help

--- a/package-lock.json
+++ b/package-lock.json
@@ -10172,10 +10172,6 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
-    "node_modules/ramoa": {
-      "resolved": "packages/cli",
-      "link": true
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10545,6 +10541,10 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rmoa": {
+      "resolved": "packages/cli",
+      "link": true
     },
     "node_modules/rollup": {
       "version": "2.79.1",
@@ -12440,7 +12440,7 @@
       }
     },
     "packages/cli": {
-      "name": "ramoa",
+      "name": "rmoa",
       "version": "0.0.0",
       "license": "See LICENSE in LICENSE.txt",
       "dependencies": {
@@ -12451,11 +12451,10 @@
         "ora": "^8.0.1",
         "pino": "^9.3.1",
         "pino-pretty": "^11.2.1",
-        "semver": "^7.5.2",
         "yargs": "^17.7.2"
       },
       "bin": {
-        "ramoa": "cli.js"
+        "rmoa": "cli.js"
       },
       "devDependencies": {
         "@types/mime-types": "^2.1.4",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -15,7 +15,7 @@ should.
 ## Installation
 
 ```bash
-npm install -g ramoa
+npm install -g rmoa
 ```
 
 ## Usage
@@ -27,16 +27,16 @@ need to create your api key on the
 To start using the CLI, run:
 
 ```bash
-ramoa --help
+rmoa --help
 ```
 
 ### Commands
 
 ```
-ramoa <command>
+rmoa <command>
 
 Commands:
-ramoa lint
+rmoa lint
 
 Lint & get a score for your OpenAPI definition using the Rate My OpenAPI ruleset
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ramoa",
+  "name": "rmoa",
   "version": "0.0.0",
   "type": "module",
   "description": "The command-line interface for Rate My Open API",
@@ -21,7 +21,7 @@
     "node": ">=20.0.0"
   },
   "bin": {
-    "ramoa": "cli.js"
+    "rmoa": "cli.js"
   },
   "devDependencies": {
     "@types/mime-types": "^2.1.4",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ try {
   );
 } catch (e) {
   await printCriticalFailureToConsoleAndExit(
-    `Unable to load ramoa. The package.json is missing or malformed.`,
+    `Unable to load rmoa. The package.json is missing or malformed.`,
   );
 }
 


### PR DESCRIPTION
This reverts commit 0378174d4630e9418a6ee678506f2ea56ce97516.

Reverting since the new name was blocked by NPM

```
npm error 403 403 Forbidden - PUT https://registry.npmjs.com/ramoa - Package name too similar to existing package ramda; try renaming your package to '@zuplo-integrations/ramoa' and publishing with 'npm publish --access=public' instead
```