### PR TITLE
Adjustments so everything fits nicely

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -17,7 +17,7 @@ header {
 }
 
 .icon-button-submit {
-  @apply icon-button bg-pink-600 transition-all hover:bg-pink-500 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:bg-none;
+  @apply icon-button bg-fuchsia-600 transition-all hover:bg-fuchsia-500 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:bg-none;
 }
 
 .button {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,17 +6,15 @@ import { UploadContextProvider } from "@/contexts/UploadContext";
 import { PageBox } from "@/components/PageBox";
 import NavigateButton from "@/components/NavigateButton";
 
-const gitHubActionCodeSample = `steps:
-  - uses: actions/checkout@v4
-  - uses: zuplo/rmoa-action@v1
+const gitHubActionCodeSample = `- uses: zuplo/rmoa-action@v1
     with:
       filepath: './my-api.json'
       apikey: \${{ secrets.API_KEY }}`;
 
 const HomePage = () => (
-  <div className="mx-4 flex flex-col items-center justify-center md:mx-0 md:mt-10">
-    <h2 className="mb-12 mt-4 max-w-3xl text-center text-5xl font-bold md:mb-16 md:mt-0 md:text-7xl">
-      We rate your OpenAPl
+  <div className="mx-4 mt-10 flex flex-col items-center justify-center md:mx-0 md:mt-8">
+    <h2 className="xl:mb-20 xl:text-7xl mb-10 mt-4 max-w-3xl text-center text-4xl font-bold md:mb-14 md:mt-0 md:text-6xl">
+      We rate your OpenAPI
     </h2>
     <UploadContextProvider>
       <div className="grid w-full max-w-4xl grid-cols-1">
@@ -24,74 +22,71 @@ const HomePage = () => (
         <EmailInput />
         <AnalyzingText />
       </div>
-      <div className="mb-4 grid gap-10 md:grid-cols-3">
-        <PageBox>
-          <h3 className="text-lg font-medium">Use the CLI</h3>
-          <p>
-            Perfect for developers who prefer working from the command line or
-            need to integrate quality checks into their development workflow.
-          </p>
-          <pre className="mt-auto whitespace-pre-wrap rounded-md bg-gray-100 px-2 py-6 font-mono text-xs">
-            <code>
-              <span>npx rmoa lint </span>
-              <span style={{ color: "rgb(54, 172, 170)" }}>--filename</span>
-              <span> </span>
-              <span style={{ color: "rgb(227, 17, 108)" }}>
-                &quot;api.json&quot;
-              </span>
-              <span style={{ color: "rgb(54, 172, 170)" }}> --api-key </span>
-              <span style={{ color: "rgb(227, 17, 108)" }}>
-                &quot;****&quot;
-              </span>
-            </code>
-          </pre>
-
-          <NavigateButton
-            label={"Get started"}
-            url={"https://www.npmjs.com/package/rmoa"}
-          />
-        </PageBox>
-
-        <PageBox>
-          <h3 className="text-lg font-medium">Use our GitHub Action</h3>
-          <p>
-            Seamlessly integrates with your repository to run on Pull Requests
-            and Pushes to ensure continuous quality monitoring and feedback.
-          </p>
-          <pre className="mt-auto whitespace-pre-wrap rounded-md bg-gray-100 p-2 font-mono text-xs">
-            <code>{gitHubActionCodeSample}</code>
-          </pre>
-
-          <NavigateButton
-            label={"Learn more"}
-            url={
-              "https://github.com/marketplace/actions/rate-my-openapi-action"
-            }
-          />
-        </PageBox>
-
-        <PageBox>
-          <h3 className="text-lg font-medium">Use our API</h3>
-          <p>
-            Great option for those developers that want to build their own tools
-            or their own integration to Rate My OpenAPI.
-          </p>
-          <div className="grid place-items-center">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/images/build-crane-logo.png"
-              width={150}
-              alt="Build your tools with the API"
-            />
-          </div>
-
-          <NavigateButton
-            label={"View docs"}
-            url={"https://api.ratemyopenapi.com/docs"}
-          />
-        </PageBox>
-      </div>
     </UploadContextProvider>
+    <div className="mb-4 grid gap-10 md:grid-cols-3">
+      <PageBox>
+        <h3 className="text-lg font-medium">Use the CLI</h3>
+        <p>
+          Perfect for developers who prefer working from the command line or
+          need to integrate quality checks into their development workflow.
+        </p>
+        <pre className="mt-auto whitespace-pre-wrap rounded-md bg-gray-100 px-2 py-6 font-mono text-xs">
+          <code>
+            <span>npx rmoa lint </span>
+            <span style={{ color: "rgb(54, 172, 170)" }}>--filename</span>
+            <span> </span>
+            <span style={{ color: "rgb(227, 17, 108)" }}>
+              &quot;api.json&quot;
+            </span>
+            <span style={{ color: "rgb(54, 172, 170)" }}> --api-key </span>
+            <span style={{ color: "rgb(227, 17, 108)" }}>&quot;****&quot;</span>
+          </code>
+        </pre>
+
+        <NavigateButton
+          label={"Get started"}
+          url={"https://www.npmjs.com/package/rmoa"}
+        />
+      </PageBox>
+
+      <PageBox>
+        <h3 className="text-lg font-medium">Use our GitHub Action</h3>
+        <p>
+          Seamlessly integrates with your repository to run on Pull Requests and
+          Pushes to ensure continuous quality monitoring and feedback.
+        </p>
+        <pre className="mt-auto whitespace-pre-wrap rounded-md bg-gray-100 p-2 font-mono text-xs">
+          <code>{gitHubActionCodeSample}</code>
+        </pre>
+
+        <NavigateButton
+          label={"Learn more"}
+          url={"https://github.com/marketplace/actions/rate-my-openapi-action"}
+        />
+      </PageBox>
+
+      <PageBox>
+        <h3 className="text-lg font-medium">Use our API</h3>
+        <p>
+          Great option for those developers that want to build their own tools
+          or their own integration to Rate My OpenAPI.
+        </p>
+        <div className="grid place-items-center">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/images/build-crane-logo.png"
+            width={130}
+            alt="Build your tools with the API"
+          />
+        </div>
+
+        <NavigateButton
+          label={"View docs"}
+          url={"https://api.ratemyopenapi.com/docs"}
+        />
+      </PageBox>
+    </div>
+
     <DynamicBackground />
   </div>
 );

--- a/apps/web/src/components/Header/index.tsx
+++ b/apps/web/src/components/Header/index.tsx
@@ -1,17 +1,17 @@
 import LogoIcon from "../LogoIcon";
 
 const Header = () => (
-  <header className="px-4 pt-4 md:pt-8">
-    <div className="flex justify-between rounded-xl bg-white p-5 shadow-md">
+  <header className="xl:pt-8 px-4 pt-4">
+    <div className="xl:p-5 flex justify-between rounded-lg bg-white p-3 shadow-md">
       <div className="relative">
         <a href="/" className="flex justify-center">
-          <h1 className=" text-2xl font-bold">
+          <h1 className="xl:text-2xl text-xl font-bold">
             rate<span className="text-gray-500">my</span>openapi
           </h1>
         </a>
       </div>
       <a href="https://zuplo.com">
-        <LogoIcon height={33} width={33} />
+        <LogoIcon height={30} width={30} />
       </a>
     </div>
   </header>

--- a/apps/web/src/components/NavigateButton/index.tsx
+++ b/apps/web/src/components/NavigateButton/index.tsx
@@ -4,7 +4,7 @@ const NavigateButton = ({ label, url }: { label: string; url: string }) => {
   return (
     <button
       type="button"
-      className="mt-auto block rounded-md bg-fuchsia-600 p-2 font-medium text-white transition-colors hover:bg-gray-900 hover:text-white"
+      className="mt-auto block rounded-md bg-fuchsia-600 p-2 font-medium text-white transition-colors hover:bg-fuchsia-500 hover:text-white"
       onClick={() => {
         window.location.href = url;
       }}

--- a/apps/web/src/components/PageBox/index.tsx
+++ b/apps/web/src/components/PageBox/index.tsx
@@ -10,7 +10,7 @@ export const PageBox = ({
 }) => (
   <div
     className={classNames(
-      "relative flex flex-col gap-4 rounded-lg bg-white p-8 shadow-md",
+      "relative flex flex-col gap-4 rounded-lg bg-white p-5 shadow-md",
       "after:absolute after:-right-1.5 after:-top-1.5 after:rounded-md after:bg-indigo-700 after:px-3 after:py-2 after:text-xs after:font-medium after:uppercase after:text-white after:content-['New']",
       className,
     )}

--- a/apps/web/src/components/RatingExamples/index.tsx
+++ b/apps/web/src/components/RatingExamples/index.tsx
@@ -20,7 +20,7 @@ const EXAMPLES: { title: string; slug: string }[] = [
 ];
 
 export const RatingExamples = ({ children }: RatingExamplesProps) => (
-  <div className="m-10 flex items-center justify-center gap-4">
+  <div className="mx-10 my-5 flex flex-col items-center justify-center gap-4 md:flex-row">
     {children ? (
       <div>{children}</div>
     ) : (


### PR DESCRIPTION
This PR includes the following changes:
- Misspell of OpenAPI on the main header
- Update the GitHub Actions code sample
- Use the same colors for active buttons
- Align code samples on the page boxes
- Prevent scrolling on laptop sized screens
- Fix mobile ordering of RatingExamples component

**Before:**
<img width="1624" alt="Screenshot 2024-07-31 at 10 03 44 AM" src="https://github.com/user-attachments/assets/707953f6-efc8-4231-a09b-765e429b5a22">

**Now:**
<img width="1624" alt="Screenshot 2024-07-31 at 10 03 54 AM" src="https://github.com/user-attachments/assets/538f4c08-9287-4c62-9b3d-fadf72ad0ccf">
