### PR TITLE
Replace GH_NPM_PACKAGE_READ_TOKEN with GITHUB_TOKEN

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ registries:
   npm-github:
     type: npm-registry
     url: https://npm.pkg.github.com
-    token: ${{secrets.GH_NPM_PACKAGE_READ_TOKEN}}
+    token: ${{secrets.GITHUB_TOKEN}}
 
 updates:
   # Maintain dependencies for GitHub Actions

--- a/.github/workflows/release-service.yaml
+++ b/.github/workflows/release-service.yaml
@@ -20,6 +20,7 @@ jobs:
     if: github.ref == 'refs/heads/main' # This can only be triggered from main
 
     permissions:
+      packages: read
       contents: "read"
       id-token: "write"
 

--- a/.github/workflows/release-service.yaml
+++ b/.github/workflows/release-service.yaml
@@ -75,7 +75,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NODE_AUTH_TOKEN=${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}
+            NODE_AUTH_TOKEN=${{ github.token }}
 
       - uses: google-github-actions/deploy-cloudrun@v1
         with:


### PR DESCRIPTION
## Summary
- Replaces `GH_NPM_PACKAGE_READ_TOKEN` PAT with native `GITHUB_TOKEN` for npm package access
- Private `@zuplo/*` packages now grant Actions access to consuming repos directly via GitHub's package permissions

## Changes
- **Workflow files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ github.token }}`
- **Dependabot files**: `${{ secrets.GH_NPM_PACKAGE_READ_TOKEN }}` → `${{ secrets.GITHUB_TOKEN }}`

## Test plan
- [ ] CI passes with the new token configuration
- [ ] Private `@zuplo/*` packages install successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)