### PR TITLE
Update OpenAI: gpt-5.4-mini + prompt refresh + resilient scoring

### DIFF
--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -1,0 +1,1 @@
+export class ReportGenerationError extends Error {}

--- a/apps/api/src/lib/rating.ts
+++ b/apps/api/src/lib/rating.ts
@@ -11,16 +11,22 @@ import { load as loadYAML } from "js-yaml";
 import * as fs from "node:fs";
 import { join } from "node:path";
 import { Worker } from "node:worker_threads";
-import OpenAI from "openai";
 import { tmpdir } from "os";
 import path from "path";
-import { getOpenAIClient } from "../services/openai.js";
+import { getOpenAiResponse } from "../services/openai-response.js";
+import {
+  longSummaryMessages,
+  shortSummaryMessages,
+} from "../prompts/rating-summary.js";
 import {
   getStorageBucket,
   getStorageBucketName,
   getStorageClient,
 } from "../services/storage.js";
+import { ReportGenerationError } from "./errors.js";
 import { OpenApiFileExtension, assertValidFileExtension } from "./types.js";
+
+export { ReportGenerationError };
 
 const { Spectral, Document } = spectralCore;
 
@@ -42,8 +48,6 @@ export interface GetReportResult {
   simpleReport: SimpleReport;
   fullReport: RatingOutput;
 }
-
-export class ReportGenerationError extends Error {}
 
 const workerPath = new URL("rating.worker.js", import.meta.url);
 
@@ -226,9 +230,17 @@ export async function getReport(options: {
   }
 
   const issueSummary = getReportMinified(output);
+  // Summaries are best-effort: autonomous flow must still publish a score even
+  // if OpenAI is down, rate-limited, or returns an error.
   const [openAiLongSummary, openAiShortSummary] = await Promise.all([
-    getOpenAiLongSummary(issueSummary),
-    getOpenAiShortSummary(issueSummary),
+    getOpenAiLongSummary(issueSummary).catch((err) => {
+      console.warn(`OpenAI long summary failed: ${err}`);
+      return null;
+    }),
+    getOpenAiShortSummary(issueSummary).catch((err) => {
+      console.warn(`OpenAI short summary failed: ${err}`);
+      return null;
+    }),
   ]);
 
   const simpleReport = {
@@ -320,60 +332,19 @@ function getReportMinified(fullReport: RatingOutput) {
     );
 }
 
-async function getOpenAiResponse(
-  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-): Promise<string | null> {
-  try {
-    const response = await getOpenAIClient()?.chat.completions.create({
-      model: "gpt-3.5-turbo",
-      messages,
-      temperature: 0.5,
-      max_tokens: 400,
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
-    });
-    return response
-      ? response.choices[0].message.content
-      : "Placeholder OpenAI response";
-  } catch (err) {
-    throw new ReportGenerationError(`Could not get OpenAI response: ${err}`, {
-      cause: err,
-    });
-  }
-}
+const getOpenAiLongSummary = (issueSummary: object) =>
+  getOpenAiResponse({
+    messages: longSummaryMessages(issueSummary),
+    temperature: 0.3,
+    maxTokens: 400,
+  });
 
-async function getOpenAiLongSummary(issueSummary: object) {
-  return await getOpenAiResponse([
-    {
-      role: "system",
-      content:
-        "You are an expert in REST API Development and know everything about OpenAPI and what makes a good API. You like chatting in a playful, and a somewhat snarky manner. Don't make fun of the user though.",
-    },
-    {
-      role: "user",
-      content: `Here's a summary of issues found in an OpenAPI file. The format is a JSON, where the first level indicates the severity of the issue (the lower the key, the more severe), the second level is the name of the issue. These mostly match up to existing spectral rulesets, so you can infer what the issue is. The third level contains the number of occurrences of that issue.\n\nI would like a succinct summary of the issues and advice on how to fix them.  Focus on the highest severity issues. Keep the tone casual and playful, and a bit snarky. Do not insult the user or API creator or the API. Also, no bullet points. Maximum of 3 issues please. Only talk about the highest severity issues. \n\nHere's the issue summary\n ${JSON.stringify(
-        issueSummary,
-      )}`,
-    },
-  ]);
-}
-
-async function getOpenAiShortSummary(issueSummary: object) {
-  return await getOpenAiResponse([
-    {
-      role: "system",
-      content:
-        "You are an expert in REST API Development and know everything about OpenAPI and what makes a good API. You like chatting in a playful, and a somewhat snarky manner. Don't make fun of the user though.",
-    },
-    {
-      role: "user",
-      content: `Here's a summary of issues found in an OpenAPI file. The format is a JSON, where the first level indicates the severity of the issue (the lower the key, the more severe), the second level is the name of the issue. These mostly match up to existing spectral rulesets, so you can infer what the issue is. The third level contains the number of occurrences of that issue.\n\nI would like a succinct summary of the issues  in 2 lines. Keep the tone casual and playful, and a bit snarky. Do not insult the user or API creator or the API. Also, no bullet points. Only talk about the highest severity issues.\n\nHere's the issue summary\n ${JSON.stringify(
-        issueSummary,
-      )}`,
-    },
-  ]);
-}
+const getOpenAiShortSummary = (issueSummary: object) =>
+  getOpenAiResponse({
+    messages: shortSummaryMessages(issueSummary),
+    temperature: 0.3,
+    maxTokens: 400,
+  });
 
 async function deleteTempFile(tempApiFilePath: string): Promise<void> {
   try {

--- a/apps/api/src/lib/rating.ts
+++ b/apps/api/src/lib/rating.ts
@@ -336,14 +336,14 @@ const getOpenAiLongSummary = (issueSummary: object) =>
   getOpenAiResponse({
     messages: longSummaryMessages(issueSummary),
     temperature: 0.3,
-    maxTokens: 400,
+    maxTokens: 1200,
   });
 
 const getOpenAiShortSummary = (issueSummary: object) =>
   getOpenAiResponse({
     messages: shortSummaryMessages(issueSummary),
     temperature: 0.3,
-    maxTokens: 400,
+    maxTokens: 1200,
   });
 
 async function deleteTempFile(tempApiFilePath: string): Promise<void> {

--- a/apps/api/src/prompts/ai-fix.ts
+++ b/apps/api/src/prompts/ai-fix.ts
@@ -1,0 +1,37 @@
+import type OpenAI from "openai";
+
+type Msg = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+export function aiFixMessages(opts: {
+  sample: unknown;
+  issue: unknown;
+  references: string;
+  format: "JSON" | "YAML";
+}): Msg[] {
+  return [
+    {
+      role: "user",
+      content: [
+        "You are reviewing an OpenAPI spec fragment and a single lint issue flagged against it.",
+        "Suggest a fix. Rules:",
+        `- If your fix changes the spec, output it in ${opts.format} inside a fenced code block.`,
+        "- Leave inline comments explaining the change.",
+        "- Structural/cleanup issues (orphans, unused components, dead refs) → suggest removal.",
+        "- Missing-data issues (absent fields, undocumented behaviour) → suggest addition.",
+        "- If the right fix isn't clear from the sample, say so explicitly rather than guessing.",
+        "",
+        "<openapi_sample>",
+        JSON.stringify(opts.sample, null, 2),
+        "</openapi_sample>",
+        "",
+        "<issue>",
+        JSON.stringify(opts.issue, null, 2),
+        "</issue>",
+        "",
+        "<references>",
+        opts.references || "none",
+        "</references>",
+      ].join("\n"),
+    },
+  ];
+}

--- a/apps/api/src/prompts/rating-summary.ts
+++ b/apps/api/src/prompts/rating-summary.ts
@@ -1,0 +1,45 @@
+import type OpenAI from "openai";
+
+const PERSONA =
+  "You are a REST API and OpenAPI expert. Tone: dry wit, good-natured ribbing, no insults aimed at the user, the author, or the API.";
+
+const GROUNDING =
+  "Issue names are Spectral rule IDs (e.g. `operation-tags`, `no-$ref-siblings`); infer the rule's intent from the name.";
+
+const FORMAT =
+  "Formatting: plain prose, no bullet points, no markdown headings.";
+
+type Msg = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+
+export function longSummaryMessages(issueSummary: object): Msg[] {
+  return [
+    { role: "system", content: PERSONA },
+    {
+      role: "user",
+      content: [
+        "Summarise the highest-severity issues in this OpenAPI lint report and suggest fixes.",
+        "Cover up to 3 issues — fewer is fine if there aren't 3 severity-0 issues. Skip lower-severity noise.",
+        GROUNDING,
+        FORMAT,
+        "Issue summary (JSON; outer key = severity, lower = more severe; inner key = rule ID; value = occurrences):",
+        "```json\n" + JSON.stringify(issueSummary) + "\n```",
+      ].join("\n\n"),
+    },
+  ];
+}
+
+export function shortSummaryMessages(issueSummary: object): Msg[] {
+  return [
+    { role: "system", content: PERSONA },
+    {
+      role: "user",
+      content: [
+        "Summarise only the highest-severity issues in this OpenAPI lint report in 2 sentences (under 220 characters total).",
+        GROUNDING,
+        FORMAT,
+        "Issue summary:",
+        "```json\n" + JSON.stringify(issueSummary) + "\n```",
+      ].join("\n\n"),
+    },
+  ];
+}

--- a/apps/api/src/routes/ai-fix.ts
+++ b/apps/api/src/routes/ai-fix.ts
@@ -200,7 +200,7 @@ export const aiFixRoute: FastifyPluginAsync = async function (server) {
           format: isJson ? "JSON" : "YAML",
         }),
         temperature: 0,
-        maxTokens: 1000,
+        maxTokens: 2000,
       });
 
       if (response === null) {

--- a/apps/api/src/routes/ai-fix.ts
+++ b/apps/api/src/routes/ai-fix.ts
@@ -203,6 +203,14 @@ export const aiFixRoute: FastifyPluginAsync = async function (server) {
         maxTokens: 1000,
       });
 
+      if (response === null) {
+        // Schema declares 200: string. OpenAI not configured or returned no
+        // content — surface a clear failure rather than violating the contract.
+        throw new ReportGenerationError(
+          "AI fix suggestion unavailable: OpenAI is not configured or returned no content.",
+        );
+      }
+
       return response;
     },
   });

--- a/apps/api/src/routes/ai-fix.ts
+++ b/apps/api/src/routes/ai-fix.ts
@@ -1,12 +1,12 @@
 import { type FastifyPluginAsync } from "fastify";
-import { getStorageBucket } from "../services/storage.js";
-import path from "path";
-import { tmpdir } from "os";
 import { readFile } from "fs/promises";
 import { load } from "js-yaml";
-import { getOpenAIClient } from "../services/openai.js";
-import OpenAI from "openai";
-export class ReportGenerationError extends Error {}
+import { tmpdir } from "os";
+import path from "path";
+import { ReportGenerationError } from "../lib/errors.js";
+import { aiFixMessages } from "../prompts/ai-fix.js";
+import { getOpenAiResponse } from "../services/openai-response.js";
+import { getStorageBucket } from "../services/storage.js";
 
 type Issue = {
   code: string | number;
@@ -24,29 +24,6 @@ type Issue = {
     };
   };
 };
-
-async function getOpenAiResponse(
-  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-): Promise<string | null> {
-  try {
-    const response = await getOpenAIClient()?.chat.completions.create({
-      model: "gpt-3.5-turbo-1106",
-      messages,
-      temperature: 0,
-      max_tokens: 1000,
-      top_p: 1,
-      frequency_penalty: 0,
-      presence_penalty: 0,
-    });
-    return response
-      ? response.choices[0].message.content
-      : "Placeholder OpenAI response";
-  } catch (err) {
-    throw new ReportGenerationError(`Could not get OpenAI response: ${err}`, {
-      cause: err,
-    });
-  }
-}
 
 /**
  * Parse out JSON references from a JSON object
@@ -215,29 +192,16 @@ export const aiFixRoute: FastifyPluginAsync = async function (server) {
         .map((reference) => JSON.stringify(reference, null, 2))
         .join(", ");
 
-      const prompt = `Given the following OpenAPI spec sample, and an issue found with that sample, please provide a suggested fix for the issue. The Sample: ${JSON.stringify(
-        issueProperty,
-        null,
-        2,
-      )}\n\n The Issue: ${JSON.stringify(
-        issue,
-        null,
-        2,
-      )}. If your suggestion is a change to the OpenAPI spec, the suggestion should be in ${
-        isJson ? "JSON" : "YAML"
-      } format. Leave inline comments explaining the changes you made. Any code blocks should use the markdown codeblock syntax. If the issue has to do with a component being orphaned, you should suggest deleting that component from the spec. ${
-        references
-          ? `Here are some components that are referenced within the OpenAPI spec sample: ${references}`
-          : ""
-      } 
-      `;
-
-      const response = await getOpenAiResponse([
-        {
-          role: "user",
-          content: prompt,
-        },
-      ]);
+      const response = await getOpenAiResponse({
+        messages: aiFixMessages({
+          sample: issueProperty,
+          issue,
+          references,
+          format: isJson ? "JSON" : "YAML",
+        }),
+        temperature: 0,
+        maxTokens: 1000,
+      });
 
       return response;
     },

--- a/apps/api/src/scripts/test-rating.ts
+++ b/apps/api/src/scripts/test-rating.ts
@@ -1,0 +1,47 @@
+import { config } from "dotenv";
+import { readFile } from "fs/promises";
+import path from "path";
+import { getReport } from "../lib/rating.js";
+import { assertValidFileExtension } from "../lib/types.js";
+
+config();
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error(
+    "Usage: node dist/scripts/test-rating.js <path-to-openapi-spec>",
+  );
+  process.exit(1);
+}
+
+const absPath = path.resolve(inputPath);
+const ext = path.extname(absPath).replace(".", "");
+assertValidFileExtension(ext);
+
+const content = await readFile(absPath, "utf-8");
+
+console.log(`Rating ${absPath}...`);
+const result = await getReport({
+  fileContent: content,
+  fileExtension: ext,
+  reportId: "local-test",
+  openAPIFilePath: absPath,
+});
+
+console.log("\n=== Scores ===");
+console.log(`overall:        ${result.simpleReport.score}`);
+console.log(`docs:           ${result.simpleReport.docsScore}`);
+console.log(`completeness:   ${result.simpleReport.completenessScore}`);
+console.log(`security:       ${result.simpleReport.securityScore}`);
+console.log(`sdkGeneration:  ${result.simpleReport.sdkGenerationScore}`);
+
+const report = result.simpleReport as typeof result.simpleReport & {
+  shortSummary?: string;
+  longSummary?: string;
+};
+
+console.log("\n=== Short summary ===");
+console.log(report.shortSummary ?? "(none)");
+
+console.log("\n=== Long summary ===");
+console.log(report.longSummary ?? "(none)");

--- a/apps/api/src/services/openai-response.ts
+++ b/apps/api/src/services/openai-response.ts
@@ -30,7 +30,8 @@ export async function getOpenAiResponse({
     });
     return response.choices[0].message.content;
   } catch (err) {
-    throw new ReportGenerationError(`Could not get OpenAI response: ${err}`, {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new ReportGenerationError(`Could not get OpenAI response: ${detail}`, {
       cause: err,
     });
   }

--- a/apps/api/src/services/openai-response.ts
+++ b/apps/api/src/services/openai-response.ts
@@ -1,0 +1,37 @@
+import type OpenAI from "openai";
+import { ReportGenerationError } from "../lib/errors.js";
+import { getOpenAIClient } from "./openai.js";
+
+const MODEL = "gpt-5.4-mini-2026-03-17";
+
+type Params = {
+  messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[];
+  temperature?: number;
+  maxTokens?: number;
+};
+
+export async function getOpenAiResponse({
+  messages,
+  temperature,
+  maxTokens,
+}: Params): Promise<string | null> {
+  try {
+    const client = getOpenAIClient();
+    if (!client) {
+      // No OPENAI_API_KEY configured. Autonomous flow must still publish a
+      // score, so return null and let the caller leave the field unset.
+      return null;
+    }
+    const response = await client.chat.completions.create({
+      model: MODEL,
+      messages,
+      temperature,
+      max_tokens: maxTokens,
+    });
+    return response.choices[0].message.content;
+  } catch (err) {
+    throw new ReportGenerationError(`Could not get OpenAI response: ${err}`, {
+      cause: err,
+    });
+  }
+}

--- a/apps/api/src/services/openai-response.ts
+++ b/apps/api/src/services/openai-response.ts
@@ -26,7 +26,8 @@ export async function getOpenAiResponse({
       model: MODEL,
       messages,
       temperature,
-      max_tokens: maxTokens,
+      max_completion_tokens: maxTokens,
+      reasoning_effort: "minimal",
     });
     return response.choices[0].message.content;
   } catch (err) {

--- a/apps/api/src/services/openai-response.ts
+++ b/apps/api/src/services/openai-response.ts
@@ -27,7 +27,9 @@ export async function getOpenAiResponse({
       messages,
       temperature,
       max_completion_tokens: maxTokens,
-      reasoning_effort: "minimal",
+      // Model accepts "none" (no reasoning) but openai SDK types lag and only
+      // include 'minimal' | 'low' | 'medium' | 'high'. Cast through unknown.
+      reasoning_effort: "none" as unknown as "low",
     });
     return response.choices[0].message.content;
   } catch (err) {

--- a/apps/api/src/services/openai.ts
+++ b/apps/api/src/services/openai.ts
@@ -3,6 +3,9 @@ import OpenAI from "openai";
 let openai: OpenAI | undefined;
 
 export function getOpenAIClient(): OpenAI | undefined {
+  if (!process.env.OPENAI_API_KEY) {
+    return undefined;
+  }
   if (!openai) {
     openai = new OpenAI({
       apiKey: process.env.OPENAI_API_KEY,

--- a/apps/web/src/app/report/[id]/report-summary.tsx
+++ b/apps/web/src/app/report/[id]/report-summary.tsx
@@ -44,7 +44,7 @@ const ReportSummary = ({
         )}
         <button
           type="button"
-          className="btn btn-ghost mt-5 self-start"
+          className="btn btn-ghost btn-sm mt-5 -ml-3"
           onClick={() => setIsExpanded(!isExpanded)}
         >
           <span>{isExpanded ? "Hide advice" : "Show advice"}</span>

--- a/apps/web/src/components/DetailedScoreSection/index.tsx
+++ b/apps/web/src/components/DetailedScoreSection/index.tsx
@@ -2,6 +2,8 @@
 
 import getScoreTextColor from "@/utils/get-score-test-color";
 import {
+  CaretDown,
+  CaretRight,
   FileMagnifyingGlass,
   Info,
   Lightning,
@@ -10,7 +12,7 @@ import {
   type Icon,
 } from "@phosphor-icons/react";
 import classNames from "classnames";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useModal } from "react-modal-hook";
 import IssueModal from "../IssueModal";
 
@@ -25,8 +27,16 @@ export type Issue = {
   };
 };
 
-const PAGE_LENGTH = 5;
-const INITIAL_LENGTH = 5;
+type GroupedIssue = {
+  code: string;
+  severity: number;
+  message: string;
+  occurrences: Issue[];
+};
+
+const INITIAL_GROUPS = 5;
+const PAGE_GROUPS = 5;
+const AUTO_EXPAND_THRESHOLD = 3;
 
 type SeverityKey = "error" | "warning" | "info" | "hint";
 
@@ -69,6 +79,63 @@ const SeverityTag = ({ severity }: { severity: number }) => {
   );
 };
 
+// Build a friendly operation label from a Spectral issue path.
+// e.g. ["paths", "/users/{id}", "get", "responses", "401"] -> "GET /users/{id}"
+// Falls back to the joined path when no HTTP verb is found.
+const HTTP_METHODS = new Set([
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+  "trace",
+]);
+
+function describeOccurrence(issue: Issue): string {
+  const parts = issue.path.map(String);
+  const pathsIdx = parts.indexOf("paths");
+  if (pathsIdx >= 0 && pathsIdx + 2 < parts.length) {
+    const route = parts[pathsIdx + 1];
+    const method = parts[pathsIdx + 2];
+    if (HTTP_METHODS.has(method.toLowerCase())) {
+      return `${method.toUpperCase()} ${route}`;
+    }
+  }
+  return parts.join(".") || "(root)";
+}
+
+function groupIssues(issues: Issue[]): GroupedIssue[] {
+  const map = new Map<string, GroupedIssue>();
+  for (const issue of issues) {
+    const code = String(issue.code);
+    const existing = map.get(code);
+    if (existing) {
+      existing.occurrences.push(issue);
+      // Keep the most-severe representative for the group header (lower = worse).
+      if (issue.severity < existing.severity) {
+        existing.severity = issue.severity;
+        existing.message = issue.message;
+      }
+    } else {
+      map.set(code, {
+        code,
+        severity: issue.severity,
+        message: issue.message,
+        occurrences: [issue],
+      });
+    }
+  }
+  return Array.from(map.values()).sort((a, b) => {
+    if (a.severity !== b.severity) return a.severity - b.severity;
+    if (a.occurrences.length !== b.occurrences.length) {
+      return b.occurrences.length - a.occurrences.length;
+    }
+    return a.message.localeCompare(b.message);
+  });
+}
+
 const DetailedScoreSection = ({
   title,
   score,
@@ -84,16 +151,36 @@ const DetailedScoreSection = ({
   openapi: string;
   fileExtension: "json" | "yaml";
 }) => {
-  const [page, setPage] = useState(0);
   const scoreTextColor = getScoreTextColor(score);
   const titleSlug = title.toLowerCase().replace(" ", "-");
+
+  const groups = useMemo(() => groupIssues(issues), [issues]);
+  const groupCount = groups.length;
   const issueCount = issues.length;
+
+  const [page, setPage] = useState(0);
   const totalPages = Math.max(
     0,
-    Math.ceil((issueCount - INITIAL_LENGTH) / PAGE_LENGTH),
+    Math.ceil((groupCount - INITIAL_GROUPS) / PAGE_GROUPS),
   );
-  const [issueToView, setIssueToView] = useState<Issue | undefined>();
+  const visibleCount = page
+    ? PAGE_GROUPS * page + INITIAL_GROUPS
+    : INITIAL_GROUPS;
+  const visibleGroups = groups.slice(0, visibleCount);
 
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+  const isExpanded = (code: string, occurrenceCount: number) => {
+    if (code in expanded) return expanded[code];
+    return occurrenceCount <= AUTO_EXPAND_THRESHOLD;
+  };
+  const toggle = (code: string, occurrenceCount: number) => {
+    setExpanded((prev) => ({
+      ...prev,
+      [code]: !isExpanded(code, occurrenceCount),
+    }));
+  };
+
+  const [issueToView, setIssueToView] = useState<Issue | undefined>();
   const handleViewClick = (issue: Issue) => {
     setIssueToView(issue);
     showModal();
@@ -110,11 +197,6 @@ const DetailedScoreSection = ({
       />
     );
   }, [issueToView]);
-
-  const visibleIssues = issues.slice(
-    0,
-    page ? PAGE_LENGTH * page + INITIAL_LENGTH : INITIAL_LENGTH,
-  );
 
   return (
     <section className="card mb-6 overflow-hidden p-0">
@@ -164,37 +246,66 @@ const DetailedScoreSection = ({
                 <th className="text-fg-faint px-5 py-2.5 text-[11px] font-semibold tracking-[0.05em] uppercase">
                   Issue
                 </th>
+                <th className="text-fg-faint w-[100px] px-5 py-2.5 text-right text-[11px] font-semibold tracking-[0.05em] uppercase">
+                  Count
+                </th>
                 <th className="text-fg-faint w-[60px] px-5 py-2.5 text-[11px] font-semibold tracking-[0.05em] uppercase" />
               </tr>
             </thead>
             <tbody>
-              {visibleIssues.map((issue, index: number) => {
-                const onActivate = () => handleViewClick(issue);
-                return (
+              {visibleGroups.map((group, groupIndex) => {
+                const expandedNow = isExpanded(
+                  group.code,
+                  group.occurrences.length,
+                );
+                const single = group.occurrences.length === 1;
+                const Caret = expandedNow ? CaretDown : CaretRight;
+                const handleHeaderActivate = () => {
+                  if (single) {
+                    handleViewClick(group.occurrences[0]);
+                  } else {
+                    toggle(group.code, group.occurrences.length);
+                  }
+                };
+                return [
                   <tr
-                    key={`${titleSlug}-table-row-${index}`}
+                    key={`${titleSlug}-group-${groupIndex}`}
                     role="button"
                     tabIndex={0}
-                    aria-label={`View issue: ${issue.message}`}
-                    onClick={onActivate}
+                    aria-expanded={single ? undefined : expandedNow}
+                    aria-label={
+                      single
+                        ? `View issue: ${group.message}`
+                        : `${expandedNow ? "Collapse" : "Expand"} ${
+                            group.occurrences.length
+                          } occurrences of ${group.message}`
+                    }
+                    onClick={handleHeaderActivate}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        onActivate();
+                        handleHeaderActivate();
                       }
                     }}
-                    className="border-bg-muted text-fg-secondary hover:bg-bg-subtle focus-visible:bg-bg-subtle focus-visible:outline-accent cursor-pointer border-b transition-colors last:border-b-0 focus-visible:outline-2 focus-visible:-outline-offset-2"
+                    className="border-bg-muted text-fg-secondary hover:bg-bg-subtle focus-visible:bg-bg-subtle focus-visible:outline-accent cursor-pointer border-b transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2"
                   >
                     <td className="px-5 py-3 align-top">
-                      <SeverityTag severity={issue.severity} />
+                      <SeverityTag severity={group.severity} />
                     </td>
                     <td className="px-5 py-3 align-top">
                       <span className="text-fg block break-words">
-                        {issue.message}
+                        {group.message}
                       </span>
-                      {typeof issue.code !== "undefined" && (
-                        <span className="text-fg-muted mt-1 block font-mono text-xs">
-                          {issue.code}
+                      <span className="text-fg-muted mt-1 block font-mono text-xs">
+                        {group.code}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 text-right align-top">
+                      {single ? (
+                        <span className="text-fg-faint text-xs">—</span>
+                      ) : (
+                        <span className="badge-numeric badge-neutral">
+                          × {group.occurrences.length}
                         </span>
                       )}
                     </td>
@@ -203,35 +314,84 @@ const DetailedScoreSection = ({
                         aria-hidden="true"
                         className="btn btn-ghost btn-icon"
                       >
-                        <FileMagnifyingGlass size={16} weight="regular" />
+                        {single ? (
+                          <FileMagnifyingGlass size={16} weight="regular" />
+                        ) : (
+                          <Caret size={16} weight="regular" />
+                        )}
                       </span>
                     </td>
-                  </tr>
-                );
+                  </tr>,
+                  !single &&
+                    expandedNow &&
+                    group.occurrences.map((occ, occIndex) => {
+                      const line = occ.range.start.line + 1;
+                      const where = describeOccurrence(occ);
+                      const onActivate = () => handleViewClick(occ);
+                      return (
+                        <tr
+                          key={`${titleSlug}-group-${groupIndex}-occ-${occIndex}`}
+                          role="button"
+                          tabIndex={0}
+                          aria-label={`View occurrence at ${where}, line ${line}`}
+                          onClick={onActivate}
+                          onKeyDown={(event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              onActivate();
+                            }
+                          }}
+                          className="border-bg-muted text-fg-muted hover:bg-bg-subtle focus-visible:bg-bg-subtle focus-visible:outline-accent bg-bg-subtle/40 cursor-pointer border-b transition-colors focus-visible:outline-2 focus-visible:-outline-offset-2"
+                        >
+                          <td className="px-5 py-2 align-top" />
+                          <td className="px-5 py-2 align-top">
+                            <div className="flex flex-col gap-1 pl-4">
+                              <span className="text-fg-secondary font-mono text-xs">
+                                {where}
+                              </span>
+                            </div>
+                          </td>
+                          <td className="px-5 py-2 text-right align-top">
+                            <span className="badge-numeric badge-neutral">
+                              L{line}
+                            </span>
+                          </td>
+                          <td className="px-3 py-2 text-right align-top">
+                            <span
+                              aria-hidden="true"
+                              className="btn btn-ghost btn-icon"
+                            >
+                              <FileMagnifyingGlass size={14} weight="regular" />
+                            </span>
+                          </td>
+                        </tr>
+                      );
+                    }),
+                ];
               })}
             </tbody>
           </table>
         </div>
       )}
 
-      {issueCount > INITIAL_LENGTH && (
+      {groupCount > INITIAL_GROUPS && (
         <div className="border-border bg-bg-subtle flex flex-col items-start gap-2 border-t px-5 py-4 md:flex-row md:items-center md:justify-between">
           <span className="text-fg-muted text-xs">
             Showing{" "}
             <span className="text-fg font-semibold">
-              {visibleIssues.length}
+              {visibleGroups.length}
             </span>{" "}
-            of <span className="text-fg font-semibold">{issueCount}</span>{" "}
-            issues
+            of <span className="text-fg font-semibold">{groupCount}</span>{" "}
+            unique issues ({issueCount} total occurrences)
           </span>
           <div className="flex flex-wrap gap-2">
-            {page < totalPages && issueCount > PAGE_LENGTH + INITIAL_LENGTH && (
+            {page < totalPages && groupCount > PAGE_GROUPS + INITIAL_GROUPS && (
               <button
                 type="button"
                 onClick={() => setPage(page + 1)}
                 className="btn btn-ghost btn-sm"
               >
-                Show {PAGE_LENGTH} more
+                Show {PAGE_GROUPS} more
               </button>
             )}
             {page < totalPages && (
@@ -240,7 +400,7 @@ const DetailedScoreSection = ({
                 onClick={() => setPage(totalPages)}
                 className="btn btn-outlined btn-sm"
               >
-                Show all {issueCount}
+                Show all {groupCount}
               </button>
             )}
             {page >= totalPages && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-config-next": "^14.1.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
-        "openai": "^4.8.0",
+        "openai": "^5.0.0",
         "prettier-plugin-tailwindcss": "^0.5.11"
       },
       "devDependencies": {
@@ -4854,28 +4854,6 @@
         "undici-types": "~5.26.4"
       }
     },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@types/node-fetch/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@types/pg": {
       "version": "8.6.1",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
@@ -6141,11 +6119,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6546,14 +6519,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -6933,14 +6898,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/css-background-parser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
@@ -7249,15 +7206,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/digest-fetch": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-      "integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-      "dependencies": {
-        "base-64": "^0.1.0",
-        "md5": "^2.3.0"
       }
     },
     "node_modules/dir-glob": {
@@ -8555,31 +8503,6 @@
         "node": ">= 0.12"
       }
     },
-    "node_modules/form-data-encoder": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
-      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="
-    },
-    "node_modules/formdata-node": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
-      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "dependencies": {
-        "node-domexception": "1.0.0",
-        "web-streams-polyfill": "4.0.0-beta.3"
-      },
-      "engines": {
-        "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-node/node_modules/web-streams-polyfill": {
-      "version": "4.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
-      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -9639,11 +9562,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
@@ -10921,16 +10839,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/mdast-util-from-markdown": {
@@ -12473,47 +12381,22 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.19.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.19.0.tgz",
-      "integrity": "sha512-cJbl0noZyAaXVKBTMMq6X5BAvP1pm2rWYDBnZes99NL+Zh5/4NmlAwyuhTZEru5SqGGZIoiYKeMPXy4bm9DI0w==",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "digest-fetch": "^1.3.0",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
-      },
+      "version": "5.23.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
+      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"
-      }
-    },
-    "node_modules/openai/node_modules/@types/node": {
-      "version": "18.18.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.10.tgz",
-      "integrity": "sha512-luANqZxPmjTll8bduz4ACs/lNTCLuWssCyjqTY9yLdsv1xnViQp3ISKwsEWOIecO13JWUqjVdig/Vjjc09o8uA==",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/openai/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
       },
       "peerDependencies": {
-        "encoding": "^0.1.0"
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
       },
       "peerDependenciesMeta": {
-        "encoding": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-next": "^14.1.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "openai": "^4.8.0",
+    "openai": "^5.0.0",
     "prettier-plugin-tailwindcss": "^0.5.11"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `openai` SDK 4.8 → 5.x; switch both call sites to `gpt-5.4-mini-2026-03-17` (off `gpt-3.5-turbo*`).
- Refresh prompts: extracted to `apps/api/src/prompts/`, dry-wit persona (resolves snark/insult conflict), Spectral rule ID grounding, "2 sentences" output spec, XML-tagged blocks in ai-fix, generalised structural/cleanup rule, "say so if unclear" escape hatch. Temp 0.5 → 0.3 on summaries; redundant defaults removed.
- Consolidated the duplicated `getOpenAiResponse` helper into `apps/api/src/services/openai-response.ts`; lifted `ReportGenerationError` into a shared `apps/api/src/lib/errors.ts`.
- Resilience: OpenAI failures (rate limit, quota, network, missing key) no longer abort report generation. Score is computed from Spectral and always publishes; summary fields fall back to `undefined`.

## Test plan
- [x] `npm run build` in `apps/api` — passes
- [x] `npm run lint` in `apps/api` — passes
- [x] Smoke a real upload against a noisy spec (e.g. `packages/internal-cli/example-specs/slack.yml`) with `OPENAI_API_KEY` set; eyeball tone of `shortSummary` / `longSummary`
- [x] POST `/v1/ai-fix/:reportName` against an issue from a recent report; confirm fenced code block in the right format (JSON/YAML) and orphan-component cases still suggest deletion
- [x] Re-run same upload twice at `temperature: 0.3` — outputs similar shape, no wild swings
- [x] Force-fail OpenAI (unset `OPENAI_API_KEY` or set bad key) and confirm report still saves with score + empty summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)