### PR TITLE
chore(deps): upgrade PostHog SDKs to latest (posthog-node major v3→v5)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -37,7 +37,7 @@
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "js-yaml": "^4.1.0",
-    "posthog-node": "^3.1.1",
+    "posthog-node": "^5.36.5",
     "serialize-error": "^11.0.1",
     "stacktrace-parser": "^0.1.10",
     "typescript": "^5.2.2"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "classnames": "^2.3.2",
     "js-yaml": "^4.1.0",
     "next": "^15.1.0",
-    "posthog-js": "^1.91.1",
+    "posthog-js": "^1.383.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-intersection-observer": "^9.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "dotenv": "^16.3.1",
         "fastify": "^4.21.0",
         "js-yaml": "^4.1.0",
-        "posthog-node": "^3.1.1",
+        "posthog-node": "^5.36.5",
         "serialize-error": "^11.0.1",
         "stacktrace-parser": "^0.1.10",
         "typescript": "^5.2.2"
@@ -173,7 +173,7 @@
         "classnames": "^2.3.2",
         "js-yaml": "^4.1.0",
         "next": "^15.1.0",
-        "posthog-js": "^1.91.1",
+        "posthog-js": "^1.383.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-intersection-observer": "^9.5.3",
@@ -2648,6 +2648,21 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.30.11",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.30.11.tgz",
+      "integrity": "sha512-B4RB0d9cnaZlZ5ewEUh18HMO45tz6TkUPYTZA+8bTyszoIwNBkKSoJcBb2eF4ldcu37eXagkewVg2vWJ3+qTqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.383.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.383.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.383.0.tgz",
+      "integrity": "sha512-/x7Rf52IajI6DWTXN7wcoUDWK2JvqCVgusbnyfbMtfwVJnEQHCxu3DC9XEMoScpWp9Pgq1XgF0L97uwwn724mA==",
+      "license": "MIT"
+    },
     "node_modules/@prisma/instrumentation": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-5.22.0.tgz",
@@ -4941,6 +4956,13 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -6885,6 +6907,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -7228,6 +7261,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {
@@ -13030,23 +13072,49 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.91.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.91.1.tgz",
-      "integrity": "sha512-Pj4mqCT8p4JdEXOwdZ1lNFU4W8a+Uv7zZs3FIBvvFnnXcMak8Fr8ns6RTTdWo3UQqZGD7iuarYcwTYI8E5UHdA==",
+      "version": "1.383.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.383.0.tgz",
+      "integrity": "sha512-94lTpimcl8tkhbnnfvyQNV3xFYQI2+rp4nl3zmWzNVPAG6aqipu78PWe72j8Gux51Y65ynOeuIoznK2Z4KZFsw==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "fflate": "^0.4.1"
+        "@posthog/core": "1.30.11",
+        "@posthog/types": "1.383.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
       }
     },
     "node_modules/posthog-node": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-3.1.3.tgz",
-      "integrity": "sha512-UaOOoWEUYTcaaDe1w0fgHW/sXvFr3RO0l7yI7RUDzkZNZCfwXNO9r3pc14d1EtNppF/SHBrV5hNiZZATpf/vUw==",
+      "version": "5.36.5",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.36.5.tgz",
+      "integrity": "sha512-ClI6LA+wDUMuMvY/fwKf4YxDHSyXrFTXWtlGGAly0Diage+mF05bH543bUSuhz1CrFPhWHQokTGPLz6wBPGA4Q==",
+      "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.0",
-        "rusha": "^0.8.14"
+        "@posthog/core": "1.30.11"
       },
       "engines": {
-        "node": ">=15.0.0"
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/prelude-ls": {
@@ -13254,6 +13322,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -13727,16 +13801,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rusha": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/rusha/-/rusha-0.8.14.tgz",
-      "integrity": "sha512-cLgakCUf6PedEu15t8kbsjnwIFFR2D4RfL+W3iWFJ4iac7z4B0ZI8fxy4R3J956kAI68HclCFGL8MPoUVC3qVA=="
-    },
     "node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15563,6 +15632,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",


### PR DESCRIPTION
Upgrades the PostHog SDKs to their latest releases.

| Workspace | Package | From | To |
|-----------|---------|------|----|
| `apps/api` | `posthog-node` | ^3.1.1 | ^5.36.5 |
| `apps/web` | `posthog-js` | ^1.91.1 | ^1.383.0 |

### posthog-node v3 → v5 review (apps/api)
Usage is confined to `src/services/posthog.ts` and `src/lib/rating.worker.ts`:
- `new PostHog(key, { host })` and `.capture({ distinctId, properties, event })` — both stable across v3/v4/v5.
- The `if (process.env.POSTHOG_KEY)` guard satisfies v5's new non-empty-key requirement.
- No use of feature flags, `captureMode`, `personProperties`/`groupProperties`, `shutdown()`, or compression — so none of the v4/v5 breaking changes apply.

Verified `apps/api` typechecks against posthog-node v5.

### posthog-js (apps/web)
Uses `init` / `capture` / `identify` / `PostHogProvider` — all stable across the v1 line. The new transitive deps in the lockfile (`dompurify`, `preact`, `web-vitals`, `core-js`) are posthog-js's own dependencies (sanitization, surveys/toolbar, web-vitals autocapture).

> Note: `tsc --build` surfaces one **pre-existing, unrelated** error in `apps/api/src/services/openai-response.ts` (`reasoning_effort` — an OpenAI SDK type-lag the code already casts around). It is unchanged on `main` and untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)