### PR TITLE
Reduce Cloud Run costs: right-size CPU/memory and scale to zero

### DIFF
--- a/.github/workflows/release-service.yaml
+++ b/.github/workflows/release-service.yaml
@@ -81,3 +81,12 @@ jobs:
         with:
           service: rate-my-openapi
           image: us-docker.pkg.dev/zuplo-marketing/docker-registry/rate-my-openapi-api:latest
+          # Cost-optimized sizing (traffic is ~20-70 requests/day; p99 usage was
+          # ~2% of 2 vCPU and ~140MiB of 2GiB before this change):
+          # - scale to zero instead of keeping a 2vCPU/2GiB instance warm 24/7
+          # - 1 vCPU / 1GiB is ample headroom for spectral/vacuum linting
+          # - keep instance-based billing (--no-cpu-throttling): /upload kicks off
+          #   runRatingWorker() AFTER the response is sent, so CPU must stay
+          #   allocated between requests while a report is being generated
+          # - --cpu-boost softens cold starts now that min-instances is 0
+          flags: --cpu=1 --memory=1Gi --min-instances=0 --max-instances=3 --concurrency=80 --no-cpu-throttling --cpu-boost


### PR DESCRIPTION
## Summary

Cost review of the `rate-my-openapi` Cloud Run service (project `zuplo-marketing`, us-central1). There is **only one environment — production**; no staging service exists, so this PR covers the full footprint.

### Current configuration vs. actual usage (last 30 days)

| Setting | Current | Actual usage |
|---|---|---|
| CPU | 2 vCPU, **always allocated** (`cpu-throttling: false`) | p99 utilization ~2% |
| Memory | 2 GiB | p99 utilization ~4–7% (~140 MiB) |
| Min instances | 1 (warm 24/7) | ~20–70 requests/**day** |
| Max instances | 10 | never scales past 1 |

With CPU always-allocated (instance-based billing) and min-instances=1, the idle baseline alone is **~$105/month** (2 vCPU × $0.000018/s ≈ $95 + 2 GiB × $0.000002/s ≈ $10) — for a service handling a few dozen requests a day at 2% utilization.

### Changes (applied via deploy workflow `flags`, so they're versioned and survive redeploys)

- **CPU 2 → 1, memory 2Gi → 1Gi** — still ~7× headroom over observed p99 memory; linting large specs has plenty of room.
- **min-instances 1 → 0** — scale to zero. `--cpu-boost` retained to soften cold starts (Fastify app starts in a couple of seconds).
- **max-instances 10 → 3** — caps burst blast radius; at concurrency 80 that's still 240 concurrent requests.
- **Kept `--no-cpu-throttling` (instance-based billing)** — this is deliberate, not an oversight: `POST /upload` fires `runRatingWorker()` *after* the response is sent (`apps/api/src/routes/upload.ts:74`) and the client polls `/report/{id}` while the report generates. Request-based billing would throttle CPU between requests and starve that background work.

### Expected savings

- Idle baseline: **~$105/mo → $0** (scale to zero).
- Active time is billed at half the vCPU/GiB footprint. With current traffic patterns (short bursts + ~15 min idle keep-alive), expected total is roughly **$5–15/month, i.e. ~90% reduction**. Absolute worst case (instance somehow pinned 24/7) is ~$53/mo — still ~50% less than today.

### Trade-offs

- First request after an idle period pays a cold start (a few seconds). For a free marketing tool at this traffic level this seems acceptable; if it isn't, restoring `--min-instances=1` at the new 1 vCPU/1 GiB size would cost ~$52/mo — still half of today.
- A background rating run could in theory be killed if Cloud Run reaps the instance mid-run, but the client's polling of `/report/{id}` keeps the instance alive during generation, and idle instances linger ~15 min before shutdown, so practical risk is minimal.

### Noted while reviewing (not in this PR)

All secrets (OpenAI, SendGrid, Slack, a full GCP service-account private key in `GOOGLE_SERVICE_ACCOUNT_B64`) are stored as plaintext env vars on the live service, visible to anyone with `run.services.get`. Worth moving to Secret Manager and rotating — happy to do as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)