### PR TITLE
Move Cloud Run secrets to Secret Manager, drop dead env vars

### DIFF
--- a/.github/workflows/release-service.yaml
+++ b/.github/workflows/release-service.yaml
@@ -89,4 +89,15 @@ jobs:
           #   runRatingWorker() AFTER the response is sent, so CPU must stay
           #   allocated between requests while a report is being generated
           # - --cpu-boost softens cold starts now that min-instances is 0
-          flags: --cpu=1 --memory=1Gi --min-instances=0 --max-instances=3 --concurrency=80 --no-cpu-throttling --cpu-boost
+          #
+          # Secrets live in Secret Manager (rate-my-openapi-* secrets in
+          # zuplo-marketing) and are wired in as env vars via --set-secrets;
+          # the runtime SA has secretAccessor on each. --remove-env-vars strips
+          # the legacy plaintext copies (and the dead GOOGLE_SERVICE_ACCOUNT_B64
+          # and INNGEST_* vars); it tolerates already-absent names, so it stays
+          # here to keep plaintext secrets from ever being reintroduced.
+          flags: >-
+            --cpu=1 --memory=1Gi --min-instances=0 --max-instances=3
+            --concurrency=80 --no-cpu-throttling --cpu-boost
+            --remove-env-vars=GOOGLE_SERVICE_ACCOUNT_B64,INNGEST_EVENT_KEY,INNGEST_SIGNING_KEY,OPENAI_API_KEY,SENDGRID_API_KEY,SLACK_TOKEN,POSTHOG_KEY
+            --set-secrets=OPENAI_API_KEY=rate-my-openapi-openai-api-key:latest,SENDGRID_API_KEY=rate-my-openapi-sendgrid-api-key:latest,SLACK_TOKEN=rate-my-openapi-slack-token:latest,POSTHOG_KEY=rate-my-openapi-posthog-key:latest

--- a/.github/workflows/release-service.yaml
+++ b/.github/workflows/release-service.yaml
@@ -92,12 +92,10 @@ jobs:
           #
           # Secrets live in Secret Manager (rate-my-openapi-* secrets in
           # zuplo-marketing) and are wired in as env vars via --set-secrets;
-          # the runtime SA has secretAccessor on each. --remove-env-vars strips
-          # the legacy plaintext copies (and the dead GOOGLE_SERVICE_ACCOUNT_B64
-          # and INNGEST_* vars); it tolerates already-absent names, so it stays
-          # here to keep plaintext secrets from ever being reintroduced.
+          # the runtime SA has secretAccessor on each. Never add secrets as
+          # plaintext env vars on the service — a name that exists as a literal
+          # will also make this deploy fail with a type conflict.
           flags: >-
             --cpu=1 --memory=1Gi --min-instances=0 --max-instances=3
             --concurrency=80 --no-cpu-throttling --cpu-boost
-            --remove-env-vars=GOOGLE_SERVICE_ACCOUNT_B64,INNGEST_EVENT_KEY,INNGEST_SIGNING_KEY,OPENAI_API_KEY,SENDGRID_API_KEY,SLACK_TOKEN,POSTHOG_KEY
             --set-secrets=OPENAI_API_KEY=rate-my-openapi-openai-api-key:latest,SENDGRID_API_KEY=rate-my-openapi-sendgrid-api-key:latest,SLACK_TOKEN=rate-my-openapi-slack-token:latest,POSTHOG_KEY=rate-my-openapi-posthog-key:latest


### PR DESCRIPTION
## What

The `rate-my-openapi` Cloud Run service stored every secret as a plaintext env var on the service (visible to anyone with `run.services.get`), including a full base64-encoded GCP service-account private key. The secrets now live in Google Secret Manager; this PR makes the deploy step declare that wiring so future deploys keep it.

Deploy step change: `--set-secrets` on `deploy-cloudrun` injects `OPENAI_API_KEY`, `SENDGRID_API_KEY`, `SLACK_TOKEN`, and `POSTHOG_KEY` from the Secret Manager secrets `rate-my-openapi-{openai-api-key,sendgrid-api-key,slack-token,posthog-key}` (`:latest`). The runtime SA has `roles/secretmanager.secretAccessor` on each.

## Already applied to the live service (one-time, via gcloud)

- Plaintext `OPENAI_API_KEY` / `SENDGRID_API_KEY` / `SLACK_TOKEN` / `POSTHOG_KEY` replaced with the secret refs above (revision `rate-my-openapi-00141-2cd`).
- **`GOOGLE_SERVICE_ACCOUNT_B64`** deleted — nothing reads it: `apps/api/src/services/storage.ts` constructs `new Storage({ projectId })`, which uses Application Default Credentials, and the service already runs as `rate-my-open-api@zuplo-marketing.iam.gserviceaccount.com`. The embedded SA key was also deleted from IAM, so the leaked key material is revoked.
- **`INNGEST_EVENT_KEY` / `INNGEST_SIGNING_KEY`** deleted — no inngest usage remains in the codebase.

Since the live service already matches what this PR declares, merging is a no-op deploy.

⚠️ Note: secrets must never be added back as plaintext env vars on the service — besides the exposure, a literal env var sharing a name with a `--set-secrets` entry makes the deploy fail with a type conflict.

## Rotation (follow-up)

The old values were readable in plaintext since 2023 and must be considered compromised. Rotate OpenAI, SendGrid, and Slack keys in each vendor dashboard, then:

```sh
printf '%s' "<new value>" | gcloud secrets versions add rate-my-openapi-<name> --project zuplo-marketing --data-file=-
```

and re-run the Release Service workflow so new instances pick up `:latest`. (`POSTHOG_KEY` is a public `phc_` client key — no rotation needed. The SA key rotation is already complete: deleted, no replacement needed under ADC.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)